### PR TITLE
Update open_evse.pde

### DIFF
--- a/open_evse.pde
+++ b/open_evse.pde
@@ -2206,7 +2206,8 @@ static inline unsigned long ulong_sqrt(unsigned long in)
 // 35 ms is just a bit longer than 1.5 cycles at 50 Hz
 #define VOLTMETER_POLL_INTERVAL (35)
 // This is just a wild guess
-#define VOLTMETER_SCALE_FACTOR (450)
+#define VOLTMETER_SCALE_FACTOR (266)
+#define VOLTMETER_OFFSET_FACTOR (40000)
 unsigned long J1772EVSEController::readVoltmeter()
 {
   unsigned int peak = 0;
@@ -2214,7 +2215,7 @@ unsigned long J1772EVSEController::readVoltmeter()
     unsigned int val = analogRead(VOLTMETER_PIN);
     if (val > peak) peak = val;
   }
-  return peak * VOLTMETER_SCALE_FACTOR;
+  return ((unsigned long)peak) * VOLTMETER_SCALE_FACTOR + VOLTMETER_OFFSET_FACTOR;
 }
 #endif
 


### PR DESCRIPTION
Experimentally, there appears to be some level of non-linearity in the voltmeter. With two datapoints available, I can make a straight-line fit. Whether that holds up or not over a larger sample size... time will have to tell.