### PR TITLE
Add Stuck Relay menu for (interim) OpenEVSE II hardware

### DIFF
--- a/open_evse.h
+++ b/open_evse.h
@@ -864,6 +864,13 @@ public:
   Menu *Select();
 };
 
+class RlyChkMenu : public Menu {
+public:
+  RlyChkMenu();
+  void Init();
+  void Next();
+  Menu *Select();
+};
 
 #endif // ADVPWR
 class ResetMenu : public Menu {

--- a/open_evse.pde
+++ b/open_evse.pde
@@ -70,6 +70,7 @@ prog_char g_psBklType[] PROGMEM = "Backlight Type";
 #endif
 #ifdef ADVPWR
 prog_char g_psGndChk[] PROGMEM = "Ground Check";
+prog_char g_psRlyChk[] PROGMEM = "Relay Check";
 #endif // ADVPWR
 prog_char g_psReset[] PROGMEM = "Restart";
 prog_char g_psExit[] PROGMEM = "Exit";
@@ -105,6 +106,7 @@ GfiTestMenu g_GfiTestMenu;
 VentReqMenu g_VentReqMenu;
 #ifdef ADVPWR
 GndChkMenu g_GndChkMenu;
+RlyChkMenu g_RlyChkMenu;
 #endif // ADVPWR
 ResetMenu g_ResetMenu;
 // Instantiate additional Menus - GoldServe
@@ -137,6 +139,7 @@ Menu *g_MenuList[] =
   &g_VentReqMenu,
 #ifdef ADVPWR
   &g_GndChkMenu,
+  &g_RlyChkMenu,
 #endif // ADVPWR
 #ifdef GFI_SELFTEST
   &g_GfiTestMenu,
@@ -2771,6 +2774,44 @@ Menu *GndChkMenu::Select()
   g_OBD.LcdPrint(g_YesNoMenuItems[m_CurIdx]);
 
   g_EvseController.EnableGndChk((m_CurIdx == 0) ? 1 : 0);
+
+  delay(500);
+
+  return &g_SetupMenu;
+}
+RlyChkMenu::RlyChkMenu()
+{
+  m_Title = g_psRlyChk;
+}
+
+void RlyChkMenu::Init()
+{
+  g_OBD.LcdPrint_P(0,m_Title);
+  m_CurIdx = g_EvseController.StuckRelayChkEnabled() ? 0 : 1;
+  sprintf(g_sTmp,"+%s",g_YesNoMenuItems[m_CurIdx]);
+  g_OBD.LcdPrint(1,g_sTmp);
+}
+
+void RlyChkMenu::Next()
+{
+  if (++m_CurIdx >= 2) {
+    m_CurIdx = 0;
+  }
+  g_OBD.LcdClearLine(1);
+  g_OBD.LcdSetCursor(0,1);
+  uint8_t dce = g_EvseController.StuckRelayChkEnabled();
+  if ((dce && !m_CurIdx) || (!dce && m_CurIdx)) {
+    g_OBD.LcdPrint("+");
+  }
+  g_OBD.LcdPrint(g_YesNoMenuItems[m_CurIdx]);
+}
+
+Menu *RlyChkMenu::Select()
+{
+  g_OBD.LcdPrint(0,1,"+");
+  g_OBD.LcdPrint(g_YesNoMenuItems[m_CurIdx]);
+
+  g_EvseController.EnableStuckRelayChk((m_CurIdx == 0) ? 1 : 0);
 
   delay(500);
 

--- a/open_evse.pde
+++ b/open_evse.pde
@@ -2194,17 +2194,6 @@ int J1772EVSEController::SetCurrentCapacity(uint8_t amps,uint8_t updatelcd)
   return rc;
 }
 
-#ifdef AMMETER
-static inline unsigned long ulong_sqrt(unsigned long in)
-{
-  unsigned long out;
-  // find the last int whose square is not too big
-  // Yes, it's wasteful, but we only theoretically ever have to go to 512.
-  // Removing floating point saves us almost 1K of flash.
-  for(out = 1; out*out <= in; out++) ;
-  return out - 1;
-}
-
 #ifdef OPENEVSE_2
 // 35 ms is just a bit longer than 1.5 cycles at 50 Hz
 #define VOLTMETER_POLL_INTERVAL (35)
@@ -2221,6 +2210,17 @@ unsigned long J1772EVSEController::readVoltmeter()
   return ((unsigned long)peak) * VOLTMETER_SCALE_FACTOR + VOLTMETER_OFFSET_FACTOR;
 }
 #endif
+
+#ifdef AMMETER
+static inline unsigned long ulong_sqrt(unsigned long in)
+{
+  unsigned long out;
+  // find the last int whose square is not too big
+  // Yes, it's wasteful, but we only theoretically ever have to go to 512.
+  // Removing floating point saves us almost 1K of flash.
+  for(out = 1; out*out <= in; out++) ;
+  return out - 1;
+}
 
 void J1772EVSEController::readAmmeter()
 {

--- a/open_evse.pde
+++ b/open_evse.pde
@@ -2206,7 +2206,8 @@ static inline unsigned long ulong_sqrt(unsigned long in)
 // 35 ms is just a bit longer than 1.5 cycles at 50 Hz
 #define VOLTMETER_POLL_INTERVAL (35)
 // This is just a wild guess
-#define VOLTMETER_SCALE_FACTOR (450)
+#define VOLTMETER_SCALE_FACTOR (266)
+#define VOLTMETER_OFFSET_FACTOR (40000)
 unsigned long J1772EVSEController::readVoltmeter()
 {
   unsigned int peak = 0;
@@ -2214,7 +2215,7 @@ unsigned long J1772EVSEController::readVoltmeter()
     unsigned int val = analogRead(VOLTMETER_PIN);
     if (val > peak) peak = val;
   }
-  return peak * VOLTMETER_SCALE_FACTOR;
+  return ((unsigned long)peak) * VOLTMETER_SCALE_FACTOR + VOLTMETER_OFFSET_FACTOR;
 }
 #endif
 


### PR DESCRIPTION
The current OpenEVSE II hardware lacks the stuck relay test hardware that will be present in the next hardware version. For now, the workaround is to disable the stuck relay test, but that's not possible via the GUI as is.