### PR TITLE
Menu/UX: Indicate that SAE Service Level 1 is meant for 120V connections only

### DIFF
--- a/firmware/open_evse/Language_default.h
+++ b/firmware/open_evse/Language_default.h
@@ -72,8 +72,8 @@
 #define STRF_KWH					     "%6lukWh" 
 #define STRF_VOLT              " %3luV"
 #define STR_AUTO					     "Auto" 
-#define STR_LEVEL_1					   "Level 1" 
-#define STR_LEVEL_2					   "Level 2"  
+#define STR_LEVEL_1					   "Level 1 (120V)" 
+#define STR_LEVEL_2					   "Level 2 (240V)"  
 #define STR_L1						     "L1"  
 #define STR_L2						     "L2"  
 //#endif

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -559,8 +559,8 @@
 
 #ifdef KWH_RECORDING
 #define VOLTS_FOR_L1 120       // conventional for North America
+#define VOLTS_FOR_L2 240       // conventional for North America and Commonwealth countries
 //  #define VOLTS_FOR_L2 230   // conventional for most of the world
-#define VOLTS_FOR_L2 240       // conventional for North America
 #endif // KWH_RECORDING
 
 // The maximum number of milliseconds to sample an ammeter pin in order to find three zero-crossings.


### PR DESCRIPTION
To help steer non-American users away from selecting Level 1
and having their Wh calculations wrong (due to VOLTS_FOR_L1
that's used in KWH_RECORDING being hardcoded to 120V).
I.e. people who select Level 1 but are running off 240V mains
are presented with kWh display that's half of the actual usage.
- move the alternative commented out define for 230V L2 voltage after
  the default 240V L2 definition, so that the 230V is not mistakenly read as being an alternative for L1

http://www.sae.org/smartgrid/chargingspeeds.pdf
