### PR TITLE
Changes to bring Platform IO build in line with Arduino build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,8 +172,11 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+# VSCode/Platform IO stuff
 .pioenvs
 .piolibdeps
 .pio
+.vscode
 .clang_complete
 .gcc-flags.json

--- a/.gitignore
+++ b/.gitignore
@@ -174,5 +174,6 @@ pip-log.txt
 .DS_Store
 .pioenvs
 .piolibdeps
+.pio
 .clang_complete
 .gcc-flags.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - pip install -U platformio
 
 script:
-  - platformio run
+  - platformio run -e $PIO_ENV
 
 after_script:
   - grep version= ~/.platformio/packages/framework-arduinoavr/platform.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,46 +20,17 @@
 #
 
 
-#
-# Template #1: General project. Test it using existing `platformio.ini`.
-#
+language: python
+python:
+  - "3.6"
 
-# language: python
-# python:
-#     - "2.7"
-#
-# sudo: false
-# cache:
-#     directories:
-#         - "~/.platformio"
-#
-# install:
-#     - pip install -U platformio
-#
-# script:
-#     - platformio run
+sudo: false
+cache:
+  directories:
+    - "~/.platformio"
 
+install:
+  - pip install -U platformio
 
-#
-# Template #2: The project is intended to by used as a library with examples
-#
-
-# language: python
-# python:
-#     - "2.7"
-#
-# sudo: false
-# cache:
-#     directories:
-#         - "~/.platformio"
-#
-# env:
-#     - PLATFORMIO_CI_SRC=path/to/test/file.c
-#     - PLATFORMIO_CI_SRC=examples/file.ino
-#     - PLATFORMIO_CI_SRC=path/to/test/directory
-#
-# install:
-#     - pip install -U platformio
-#
-# script:
-#     - platformio ci --lib="." --board=ID_1 --board=ID_2 --board=ID_N
+script:
+  - platformio run

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,22 @@ python:
   - "2.7"
 
 env:
-  - PIO_ENV=openevse
-  - PIO_ENV=openevse_1-6-14
-  - PIO_ENV=openevse_1-6-17
-  - PIO_ENV=openevse_1-6-23
+  - BUILD_ENV=platformio
+    PIO_ENV=openevse
+  - BUILD_ENV=platformio
+    PIO_ENV=openevse_1-6-14
+  - BUILD_ENV=platformio
+    PIO_ENV=openevse_1-6-17
+  - BUILD_ENV=platformio
+    PIO_ENV=openevse_1-6-23
+  - BUILD_ENV=arduino
+    AVR_CORE_VERSION=1.6.14
+  - BUILD_ENV=arduino
+    AVR_CORE_VERSION=1.6.15
+  - BUILD_ENV=arduino
+    AVR_CORE_VERSION=1.6.17
+  - BUILD_ENV=arduino
+    AVR_CORE_VERSION=1.6.23
 
 sudo: false
 cache:
@@ -36,12 +48,10 @@ cache:
     - "~/.platformio"
 
 install:
-  - pip install -U platformio
-  - pio upgrade
-  - pio --version
+  - bash -e ci/install_${BUILD_ENV:platformio}.sh
 
 script:
-  - platformio run -e $PIO_ENV
+  - bash -e ci/build_${BUILD_ENV:platformio}.sh
 
 after_script:
   - grep version= ~/.platformio/packages/framework-arduinoavr/platform.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,20 @@ python:
 
 env:
   - PIO_ENV=openevse
-  - BUILD_ENV=platformio
-    PIO_ENV=openevse_1-6-14
-  - BUILD_ENV=platformio
-    PIO_ENV=openevse_1-6-17
-  - BUILD_ENV=platformio
-    PIO_ENV=openevse_1-6-23
-  - BUILD_ENV=platformio
-    AVR_CORE_VERSION=1.6.14
-  - BUILD_ENV=arduino
-    AVR_CORE_VERSION=1.6.15
-  - BUILD_ENV=arduino
-    AVR_CORE_VERSION=1.6.17
-  - BUILD_ENV=arduino
-    AVR_CORE_VERSION=1.6.23
+    BUILD_ENV=platformio
+  - PIO_ENV=openevse_1-6-14
+    BUILD_ENV=platformio
+  - PIO_ENV=openevse_1-6-17
+    BUILD_ENV=platformio
+  - PIO_ENV=openevse_1-6-23
+    BUILD_ENV=platformio
+  - AVR_CORE_VERSION=1.6.14
+    BUILD_ENV=arduino
+  - AVR_CORE_VERSION=1.6.15
+    BUILD_ENV=arduino
+  - AVR_CORE_VERSION=1.6.17
+    BUILD_ENV=arduino
+  - AVR_CORE_VERSION=1.6.23
     BUILD_ENV=arduino
 
 sudo: false
@@ -49,10 +49,10 @@ cache:
     - "~/.arduino15"
 
 install:
-  - bash -e ci/install_${BUILD_ENV:platformio}.sh
+  - bash -e ci/install_${BUILD_ENV:-platformio}.sh
 
 script:
-  - bash -e ci/build_${BUILD_ENV:platformio}.sh
+  - bash -e ci/build_${BUILD_ENV:-platformio}.sh
 
 after_script:
-  - bash -e ci/info_${BUILD_ENV:platformio}.sh
+  - bash -e ci/info_${BUILD_ENV:-platformio}.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ cache:
 
 install:
   - pip install -U platformio
+  - pio upgrade
+  - pio --version
 
 script:
   - platformio run -e $PIO_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,4 @@ script:
   - bash -e ci/build_${BUILD_ENV:platformio}.sh
 
 after_script:
-  - grep version= ~/.platformio/packages/framework-arduinoavr/platform.txt
-  - ~/.platformio/packages/toolchain-atmelavr/bin/avr-gcc --version
-  - ls -l .pio/build/$PIO_ENV/firmware.hex
+  - bash -e ci/info_${BUILD_ENV:platformio}.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,14 @@ python:
   - "2.7"
 
 env:
-  - BUILD_ENV=platformio
-    PIO_ENV=openevse
+  - PIO_ENV=openevse
   - BUILD_ENV=platformio
     PIO_ENV=openevse_1-6-14
   - BUILD_ENV=platformio
     PIO_ENV=openevse_1-6-17
   - BUILD_ENV=platformio
     PIO_ENV=openevse_1-6-23
-  - BUILD_ENV=arduino
+  - BUILD_ENV=platformio
     AVR_CORE_VERSION=1.6.14
   - BUILD_ENV=arduino
     AVR_CORE_VERSION=1.6.15
@@ -41,11 +40,13 @@ env:
     AVR_CORE_VERSION=1.6.17
   - BUILD_ENV=arduino
     AVR_CORE_VERSION=1.6.23
+    BUILD_ENV=arduino
 
 sudo: false
 cache:
   directories:
     - "~/.platformio"
+    - "~/.arduino15"
 
 install:
   - bash -e ci/install_${BUILD_ENV:platformio}.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@
 
 language: python
 python:
-  - "3.6"
+  - "2.7"
 
 env:
   - PIO_ENV=openevse

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ language: python
 python:
   - "3.6"
 
+env:
+  - PIO_ENV=openevse
+  - PIO_ENV=openevse_1-6-14
+  - PIO_ENV=openevse_1-6-17
+  - PIO_ENV=openevse_1-6-23
+
 sudo: false
 cache:
   directories:
@@ -34,3 +40,8 @@ install:
 
 script:
   - platformio run
+
+after_script:
+  - grep version= ~/.platformio/packages/framework-arduinoavr/platform.txt
+  - ~/.platformio/packages/toolchain-atmelavr/bin/avr-gcc --version
+  - ls -l .pio/build/$PIO_ENV/firmware.hex

--- a/ci/build_arduino.sh
+++ b/ci/build_arduino.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -o xtrace
 
-arduino-cli compile -b arduino:avr:openevse firmware/open_evse
+arduino-cli compile -b arduino:avr:openevse -v firmware/open_evse

--- a/ci/build_arduino.sh
+++ b/ci/build_arduino.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -o xtrace
+
+arduino-cli compile -b arduino:avr:openevse firmware/open_evse

--- a/ci/build_platformio.sh
+++ b/ci/build_platformio.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -o xtrace
+
+platformio run -e $PIO_ENV

--- a/ci/info_arduino.sh
+++ b/ci/info_arduino.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+ARDUINO_DIR=~/.arduino15/packages/arduino
+AVR_CORE_VERSION=${AVR_CORE_VERSION:-'1.6.15'}
+AVR_CORE_DIR=$ARDUINO_DIR/hardware/avr/$AVR_CORE_VERSION
+
+# EVIL, should use `jq`
+GCC_PACKAGE=$(grep "\"avr\"" ~/.arduino15/package_index.json -A 100 | grep "\"$AVR_CORE_VERSION\"" -A 100 | grep "\"avr-gcc\"" -A 1 | grep "\"version\"" | head -n 1 | cut -d \" -f4)
+TOOLCHAIN=$ARDUINO_DIR/tools/avr-gcc/$GCC_PACKAGE
+
+ELF=firmware/open_evse/open_evse.arduino.avr.openevse.elf
+HEX=firmware/open_evse/open_evse.arduino.avr.openevse.hex
+
+source $(dirname $0)/info_common.sh

--- a/ci/info_common.sh
+++ b/ci/info_common.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+ARDUINO_VERSION=$(grep version= $AVR_CORE_DIR/platform.txt | cut -f2 -d=)
+GCC_VERSION=$($TOOLCHAIN/bin/avr-gcc --version | head -n 1)
+HEX_SIZE=$(ls -l $HEX | awk '{ print $5 }')
+
+echo
+echo "Arduino AVR Version: $ARDUINO_VERSION"
+echo "GCC Version: $GCC_VERSION"
+echo "Binary Size: $HEX_SIZE"
+echo
+$TOOLCHAIN/bin/avr-size $ELF

--- a/ci/info_platformio.sh
+++ b/ci/info_platformio.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+TOOLCHAIN=~/.platformio/packages/toolchain-atmelavr
+AVR_CORE_DIR=~/.platformio/packages/framework-arduinoavr
+ELF=.pio/build/$PIO_ENV/firmware.elf
+HEX=.pio/build/$PIO_ENV/firmware.hex
+
+source $(dirname $0)/info_common.sh

--- a/ci/install_arduino.sh
+++ b/ci/install_arduino.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -o xtrace
+
+ARDUINO_DIR=~/.arduino15/packages/arduino
+AVR_CORE_VERSION=${AVR_CORE_VERSION:-'1.6.15'}
+AVR_CORE_DIR=$ARDUINO_DIR/hardware/avr/$AVR_CORE_VERSION
+
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sudo BINDIR=/usr/local/bin sh
+arduino-cli core install arduino:avr@$AVR_CORE_VERSION
+mkdir -p $AVR_CORE_DIR
+cp arduino/1.6.15/boards.local.txt $AVR_CORE_DIR

--- a/ci/install_arduino.sh
+++ b/ci/install_arduino.sh
@@ -6,6 +6,7 @@ AVR_CORE_VERSION=${AVR_CORE_VERSION:-'1.6.15'}
 AVR_CORE_DIR=$ARDUINO_DIR/hardware/avr/$AVR_CORE_VERSION
 
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sudo BINDIR=/usr/local/bin sh
+arduino-cli core update-index
 arduino-cli core install arduino:avr@$AVR_CORE_VERSION
 mkdir -p $AVR_CORE_DIR
 cp arduino/1.6.15/boards.local.txt $AVR_CORE_DIR

--- a/ci/install_platformio.sh
+++ b/ci/install_platformio.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -o xtrace
+
+pip install -U platformio
+pio upgrade
+pio --version

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,15 +8,22 @@
 ; http://docs.platformio.org/en/stable/projectconf.html
 
 [platformio]
-env_default = openevse
+default_envs = openevse
 src_dir = firmware/open_evse
 
 [common]
 lib_deps =
 
 [env:openevse]
-platform = atmelavr
-board = OpenEVSE
+
+# Arduino 1.6.14
+#platform = atmelavr@1.4.0
+# Arduino 1.6.17
+#platform = atmelavr@1.4.1
+# Arduino 1.6.23
+platform = atmelavr@1.15.0
+
+board = openevse
 framework = arduino
 lib_deps = ${common.lib_deps}
 upload_protocol = usbasp

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,8 @@ src_dir = firmware/open_evse
 
 [common]
 lib_deps =
+upload_protocol = usbasp
+upload_flags = -p m328p -B0.5 -Pusb
 
 [env:openevse]
 
@@ -26,5 +28,29 @@ platform = atmelavr@1.15.0
 board = openevse
 framework = arduino
 lib_deps = ${common.lib_deps}
-upload_protocol = usbasp
-upload_flags = -p m328p -B0.5 -Pusb
+upload_protocol = ${common.upload_protocol}
+upload_flags = ${common.upload_flags}
+
+[env:openevse_1-6-14]
+platform = atmelavr@1.4.0
+board = openevse
+framework = arduino
+lib_deps = ${common.lib_deps}
+upload_protocol = ${common.upload_protocol}
+upload_flags = ${common.upload_flags}
+
+[env:openevse_1-6-17]
+platform = atmelavr@1.4.1
+board = openevse
+framework = arduino
+lib_deps = ${common.lib_deps}
+upload_protocol = ${common.upload_protocol}
+upload_flags = ${common.upload_flags}
+
+[env:openevse_1-6-23]
+platform = atmelavr@1.15.0
+board = openevse
+framework = arduino
+lib_deps = ${common.lib_deps}
+upload_protocol = ${common.upload_protocol}
+upload_flags = ${common.upload_flags}


### PR DESCRIPTION
These changes fix the 'Arduino' version when building with Platform IO to make sure both Platform IO and Arduino can be used to generate certified builds.

As part of this I have added Travis CI config that builds with various AVR cors both with Platform IO and Arduino. 

I did try to find a Platform IO version that matches 1.6.15 but the there is a jump from 1.6.14 to 1.6.17. Note the compiler version between those is the same and also the only real change between those packages is the `boards.txt` so _should_ be equivalent to 1.6.15.

See https://travis-ci.org/jeremypoulter/open_evse/builds/582162466 for some example builds with Travis CI. I added a little script that outputs a few key details:

Arduino CLI, AVR core 1.6.15:
```
Arduino AVR Version: 1.6.15
GCC Version: avr-gcc (GCC) 4.9.2
Binary Size: 91261
   text	   data	    bss	    dec	    hex	filename
  31710	    732	    840	  33282	   8202	firmware/open_evse/open_evse.arduino.avr.openevse.elf
```

Platform IO, AVR core 1.6.14
```
Arduino AVR Version: 1.6.14
GCC Version: avr-gcc (GCC) 4.9.2
Binary Size: 91261
   text	   data	    bss	    dec	    hex	filename
  31710	    732	    840	  33282	   8202	.pio/build/openevse_1-6-14/firmware.elf
```

Arduino CLI, AVR core 1.6.23
```
Arduino AVR Version: 1.6.23
GCC Version: avr-gcc (GCC) 5.4.0
Binary Size: 90423
   text	   data	    bss	    dec	    hex	filename
  31398	    742	    828	  32968	   80c8	firmware/open_evse/open_evse.arduino.avr.openevse.elf
```

Platform IO, AVR core 1.6.23
```
Arduino AVR Version: 1.6.23
GCC Version: avr-gcc (AVR_8_bit_GNU_Toolchain_3.6.2_1759) 5.4.0
Binary Size: 90423
   text	   data	    bss	    dec	    hex	filename
  31398	    742	    828	  32968	   80c8	.pio/build/openevse_1-6-23/firmware.elf
```

I think with the platform version fixed in Platform IO, at least on the surface the binaries look identical to the ones produced by equivalent AVR core versions with Arduino IDE/CLI.