### PR TITLE
Size optimization

### DIFF
--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -114,7 +114,7 @@ class J1772EVSEController {
 #ifdef GFI
   Gfi m_Gfi;
   unsigned long m_GfiFaultStartMs;
-  unsigned long m_GfiRetryCnt;
+  uint8_t m_GfiRetryCnt;
   uint8_t m_GfiTripCnt; // contains tripcnt-1
 #endif // GFI
   AdcPin adcPilot;
@@ -148,7 +148,7 @@ class J1772EVSEController {
 #endif
 #ifdef ADVPWR
   unsigned long m_NoGndStart;
-  unsigned long m_NoGndRetryCnt;
+  uint8_t m_NoGndRetryCnt;
   uint8_t m_NoGndTripCnt; // contains tripcnt-1
   unsigned long m_StuckRelayStartTimeMS;
   uint8_t m_StuckRelayTripCnt; // contains tripcnt-1

--- a/firmware/open_evse/RTClib.cpp
+++ b/firmware/open_evse/RTClib.cpp
@@ -16,8 +16,6 @@
  #include <WProgram.h>
 #endif
 
-int i = 0; //The new wire library needs to take an int when you are sending for the zero register
-////////////////////////////////////////////////////////////////////////////////
 // utility code, some of this could be exposed in the DateTime API if needed
 
 const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 }; //has to be const or compiler compaints
@@ -139,7 +137,7 @@ uint8_t RTC_DS1307::begin(void) {
 
 uint8_t RTC_DS1307::isrunning(void) {
   Wire.beginTransmission(DS1307_ADDRESS);
-  Wire.write(i);	
+  Wire.write(0);
   Wire.endTransmission();
 
   Wire.requestFrom(DS1307_ADDRESS, 1);
@@ -149,7 +147,7 @@ uint8_t RTC_DS1307::isrunning(void) {
 
 void RTC_DS1307::adjust(const DateTime& dt) {
     Wire.beginTransmission(DS1307_ADDRESS);
-    Wire.write(i);
+    Wire.write(0);
     Wire.write(bin2bcd(dt.second()));
     Wire.write(bin2bcd(dt.minute()));
     Wire.write(bin2bcd(dt.hour()));
@@ -157,13 +155,13 @@ void RTC_DS1307::adjust(const DateTime& dt) {
     Wire.write(bin2bcd(dt.day()));
     Wire.write(bin2bcd(dt.month()));
     Wire.write(bin2bcd(dt.year() - 2000));
-    Wire.write(i);
+    Wire.write(0);
     Wire.endTransmission();
 }
 
 DateTime RTC_DS1307::now() {
   Wire.beginTransmission(DS1307_ADDRESS);
-  Wire.write(i);	
+  Wire.write(0);
   Wire.endTransmission();
   
   Wire.requestFrom(DS1307_ADDRESS, 7);
@@ -182,7 +180,7 @@ DateTime RTC_DS1307::now() {
 
 uint8_t RTC_DS1307::isrunning(void) {
   Wire.beginTransmission(DS1307_ADDRESS);
-  Wire.send(i);	
+  Wire.send(0);
   Wire.endTransmission();
 
   Wire.requestFrom(DS1307_ADDRESS, 1);
@@ -192,7 +190,7 @@ uint8_t RTC_DS1307::isrunning(void) {
 
 void RTC_DS1307::adjust(const DateTime& dt) {
     Wire.beginTransmission(DS1307_ADDRESS);
-    Wire.send(i);
+    Wire.send(0);
     Wire.send(bin2bcd(dt.second()));
     Wire.send(bin2bcd(dt.minute()));
     Wire.send(bin2bcd(dt.hour()));
@@ -200,13 +198,13 @@ void RTC_DS1307::adjust(const DateTime& dt) {
     Wire.send(bin2bcd(dt.day()));
     Wire.send(bin2bcd(dt.month()));
     Wire.send(bin2bcd(dt.year() - 2000));
-    Wire.send(i);
+    Wire.send(0);
     Wire.endTransmission();
 }
 
 DateTime RTC_DS1307::now() {
   Wire.beginTransmission(DS1307_ADDRESS);
-  Wire.send(i);	
+  Wire.send(0);
   Wire.endTransmission();
   
   Wire.requestFrom(DS1307_ADDRESS, 7);

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -1307,10 +1307,8 @@ class DelayTimer {
   uint8_t m_StartTimerMin;
   uint8_t m_StopTimerHour;
   uint8_t m_StopTimerMin;
-  uint8_t m_CurrHour;
-  uint8_t m_CurrMin;
-  unsigned long m_LastCheck;
   uint8_t m_ManualOverride;
+  unsigned long m_LastCheck;
 public:
   DelayTimer(){
     m_LastCheck = - (60ul * 1000ul);

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -2307,12 +2307,12 @@ uint8_t DelayTimer::IsInAwakeTimeInterval()
 
   if (IsTimerEnabled() && IsTimerValid()) {
     g_CurrTime = g_RTC.now();
-    m_CurrHour = g_CurrTime.hour();
-    m_CurrMin = g_CurrTime.minute();
+    uint8_t currHour = g_CurrTime.hour();
+    uint8_t currMin = g_CurrTime.minute();
     
     uint16_t startTimerMinutes = m_StartTimerHour * 60 + m_StartTimerMin; 
     uint16_t stopTimerMinutes = m_StopTimerHour * 60 + m_StopTimerMin;
-    uint16_t currTimeMinutes = m_CurrHour * 60 + m_CurrMin;
+    uint16_t currTimeMinutes = currHour * 60 + currMin;
 
     if (stopTimerMinutes < startTimerMinutes) { //End time is for next day 
       


### PR DESCRIPTION
First off, thanks so much for this project! I enjoyed building my OpenEVSE hardware unit a few weeks ago and wanted to contribute back, so I've already made a few pull requests to the Wifi interface. I wanted to contribute to the firmware as well. so here is my first attempt.

I've noticed a frequent concern is memory usage, since the board is rather limited in space. I thought I'd poke around a bit and find some things that could be shrunk or eliminated to save both RAM and Flash space. Thus far, I've identified a few things, each split into an individual commit (with size stats noted in the commit message) in case any of them seem risky or incorrect. Overall, these changes save 124 bytes of Flash and 8 bytes of RAM.

Starting point (commit ad4400dc):
```
RAM:   [=======   ]  66.1% (used 1353 bytes from 2048 bytes)
Flash: [========= ]  90.0% (used 29502 bytes from 32768 bytes)
```

Ending point (this branch):
```
RAM:   [=======   ]  65.7% (used 1345 bytes from 2048 bytes)
Flash: [========= ]  89.7% (used 29378 bytes from 32768 bytes)
```