### PR TITLE
Remove PP_TABLE_IEC define

### DIFF
--- a/firmware/open_evse/AutoCurrentCapacityController.cpp
+++ b/firmware/open_evse/AutoCurrentCapacityController.cpp
@@ -16,7 +16,6 @@
 
 #ifdef PP_AUTO_AMPACITY
 
-#ifdef PP_TABLE_IEC
 static PP_AMPS s_ppAmps[] = {
   {0,0},
   {93,63},  // 100 = 93
@@ -25,7 +24,6 @@ static PP_AMPS s_ppAmps[] = {
   {615,13}, // 1.5K = 615
   {1023,0}
 };
-#endif //PP_TABLE_IEC
 
 AutoCurrentCapacityController::AutoCurrentCapacityController() :
   adcPP(PP_PIN)

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -114,7 +114,6 @@
 
 #ifdef PP_AUTO_AMPACITY
 #define STATE_TRANSITION_REQ_FUNC
-#define PP_TABLE_IEC
 
 #include "AutoCurrentCapacityController.h"
 


### PR DESCRIPTION
When PP_TABLE_TESLA was removed in commit 7f772c469f7, this was left as
the only remaining table, and must always be defined if PP_AUTO_AMPACITY
is defined.