### PR TITLE
Recode energy meter usage calculation for better accuracy

### DIFF
--- a/firmware/open_evse/EnergyMeter.cpp
+++ b/firmware/open_evse/EnergyMeter.cpp
@@ -10,11 +10,14 @@ EnergyMeter::EnergyMeter()
   m_bFlags = 0;
   m_wattSeconds = 0;
 
-  if (eeprom_read_dword((uint32_t*)EOFS_KWH_ACCUMULATED) == 0xffffffff) { // Check for unitialized eeprom condition so it can begin at 0kWh
-    eeprom_write_dword((uint32_t*)EOFS_KWH_ACCUMULATED,0); //  Set the four bytes to zero just once in the case of unitialized eeprom
+  // check for unitialized eeprom condition so it can begin at 0kWh
+  if (eeprom_read_dword((uint32_t*)EOFS_KWH_ACCUMULATED) == 0xffffffff) {
+    // set the four bytes to zero just once in the case of unitialized eeprom
+    eeprom_write_dword((uint32_t*)EOFS_KWH_ACCUMULATED,0);
   }
   
-  m_wattHoursTot = eeprom_read_dword((uint32_t*)EOFS_KWH_ACCUMULATED);        // get the stored value for the kWh from eeprom
+  // get the stored value for the kWh from eeprom
+  m_wattHoursTot = eeprom_read_dword((uint32_t*)EOFS_KWH_ACCUMULATED);
 }
 
 void EnergyMeter::Update()
@@ -34,7 +37,6 @@ void EnergyMeter::Update()
   if (inSession()) {
     uint8_t relayclosed = g_EvseController.RelayIsClosed();
 
-    
     if (relayclosed) {
       if (!relayClosed()) {
 	// relay just closed - don't calc, just reset timer
@@ -58,12 +60,44 @@ void EnergyMeter::calcUsage()
   unsigned long curms = millis();
   unsigned long dms = curms - m_lastUpdateMs;
   if (dms > KWH_CALC_INTERVAL_MS) {
+      uint32_t mv = g_EvseController.GetVoltage();
       uint32_t ma = g_EvseController.GetChargingCurrent();
-#ifdef THREEPHASE //Multiple L1 current by the square root of 3 to get 3-phase energy
-      m_wattSeconds += ((g_EvseController.GetVoltage()/1000UL) * (ma/1000UL) * dms * 3) / 1000UL;
-#else // !THREEPHASE
-      m_wattSeconds += ((g_EvseController.GetVoltage()/1000UL) * (ma/1000UL) * dms) / 1000UL;
+      /*
+       * The straightforward formula to compute 'milliwatt-seconds' would be:
+       *     mws = (mv/1000) * (ma/1000) * dms;
+       *
+       * However, this has some serious drawbacks, namely, truncating values
+       * when using integer math. This can introduce a lot of error!
+       *     5900 milliamps -> 5.9 amps (float) -> 5 amps (integer)
+       *     0.9 amps difference / 5.9 amps -> 15.2% error
+       *
+       * The crazy equation below helps ensure our intermediate results always
+       * fit in a 32-bit unsigned integer, but retain as much precision as
+       * possible throughout the calculation. Here is how it was derived:
+       *     mws = (mv/1000) * (ma/1000) * dms;
+       *     mws = (mv/(2**3 * 5**3)) * (ma/(2**3 * 5**3)) * dms;
+       *     mws = (mv/2**3) * (ma/(2**3) / 5**6 * dms;
+       *     mws = (mv/2**4) * (ma/(2**2) / 5**6 * dms;
+       *
+       * By breaking 1000 into prime factors of 2 and 5, and shifting things
+       * around, we almost match the precision of floating-point math.
+       *
+       * Using 16 and 4 divisors, rather than 8 and 8, helps precision because
+       * mv is always greater than ~100000, but ma can be as low as ~6000.
+       *
+       * A final note- the divisions by factors of 2 are done with right shifts
+       * by the compiler, so the revised equation, although it looks quite
+       * complex, only requires one divide operation.
+       */
+      uint32_t mws = (mv/16) * (ma/4) / 15625 * dms;
+#ifdef THREEPHASE
+      // Multiply calculation by 3 to get 3-phase energy.
+      // Typically you'd multiply by sqrt(3), but because voltage is measured to
+      // ground (230V) rather than between phases (400 V), 3 is the correct multiple.
+      mws *= 3;
 #endif // THREEPHASE
+      // convert milliwatt-seconds to watt-seconds and increment counter
+      m_wattSeconds += mws / 1000;
 
       m_lastUpdateMs = curms;
   }


### PR DESCRIPTION
For amps and volt measurements with large decimal portions (e.g. 11.9
amps, or 119.9 volts), we were introducing a pretty serious truncation
error in our existing calcUsage function. This is due to using integer
math and the default behavior of truncation, and dividing earlier than
necessary, causing a loss of precision.

The new code is extensively commented to describe what it is doing and
how it works, so hopefully no one is confused in the future with the
rather odd coefficients involved. The important part to note is never
getting too close to the upper limits of what a uint32_t variable can
handle.

The easy way to look at this and believe that it is the equivalent operation, but not as quick to truncate, is to multiply the divisors involved:
`1000 * 1000 == 1,000,000 == 16 * 4 * 15625`.

To calculate the error the existing code was potentially introducing, and to test a fix, I put the following test harness together: https://gist.github.com/toofishes/f50fce0e051f1e0c685544f3cf5a21a2
It is basically the existing `calcUsage` function along with other bits of the code needed to run and execute it. There are three function versions present in the file, and it can be compiled on your PC (`g++ -Wall -Os test.cpp`) to try it out:
a) `calcUsage`, the existing function
b) `calcUsageNew`, the proposed replacement
c) `calcUsageDouble`, which uses floating point math so we get the "true" result

Here's the result of this testing, which shows that in a contrived worse case scenario, the existing code can under-record delivered power by 17% in relative terms, or 100-300 Ws in absolute terms. The new function is generally equal to or within 1 Ws of the floating point calculated value.

```
Slowest standard charge rate possible, realistic worst case scenario for old code
114.999 Volts, 5.999 Amps, 999 ms elapsed
Using FP: 689 Ws
Original: 569 Ws	Error: 17.417%	120 Ws
New:      688 Ws	Error: 0.145%	1 Ws

A fairly typical US Level 1 setup on a 15 amp circuit
119.900 Volts, 11.900 Amps, 999 ms elapsed
Using FP: 1425 Ws
Original: 1307 Ws	Error: 8.281%	118 Ws
New:      1424 Ws	Error: 0.070%	1 Ws

A typical EU setup on a 32 amp circuit
229.900 Volts, 31.900 Amps, 999 ms elapsed
Using FP: 7326 Ws
Original: 7091 Ws	Error: 3.208%	235 Ws
New:      7325 Ws	Error: 0.014%	1 Ws

Higher powered US Level 2 dedicated 40 amp circuit
239.900 Volts, 39.900 Amps, 999 ms elapsed
Using FP: 9562 Ws
Original: 9311 Ws	Error: 2.625%	251 Ws
New:      9561 Ws	Error: 0.010%	1 Ws

The highest values this code should ever see
249.900 Volts, 79.900 Amps, 999 ms elapsed
Using FP: 19947 Ws
Original: 19651 Ws	Error: 1.484%	296 Ws
New:      19946 Ws	Error: 0.005%	1 Ws
```