### PR TITLE
Added eventing of button presses

### DIFF
--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -28,7 +28,6 @@
 #include <avr/eeprom.h>
 #include <pins_arduino.h>
 #include "./Wire.h"
-#include "./Time.h"
 #include "avrstuff.h"
 #include "i2caddr.h"
 
@@ -46,6 +45,8 @@
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer
+
+typedef unsigned long time_t;
 
 //Language preferences: Add your custom languagefile here. See Language_default.h for more info.
 //#include "Language_norwegian.h"

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -90,7 +90,10 @@ typedef unsigned long time_t;
 #define RAPI_SERIAL
 
 // RAPI $WF support
-//#define RAPI_WF
+#define RAPI_WF
+
+// RAPI $AN support
+#define RAPI_BTN
 
 // RAPI over I2C
 //#define RAPI_I2C

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -2186,7 +2186,17 @@ int8_t BtnHandler::DoShortPress(int8_t infaultstate)
 
 void BtnHandler::ChkBtn()
 {
-  if (!g_EvseController.ButtonIsEnabled()) return;
+  if (!g_EvseController.ButtonIsEnabled()) {
+#ifdef RAPI_BTN
+    m_Btn.read();
+    if (m_Btn.shortPress()) {
+      RapiSendButtonPress(0);
+    } else if (m_Btn.longPress()) {
+      RapiSendButtonPress(1);
+    }
+#endif // RAPI_BTN
+    return;
+  }
 
   WDT_RESET();
 

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -168,6 +168,17 @@ void EvseRapiProcessor::setWifiMode(uint8_t mode)
 }
 #endif // RAPI_WF
 
+#ifdef RAPI_BTN
+void EvseRapiProcessor::sendButtonPress(uint8_t long_press)
+{
+  sprintf(g_sTmp,"%cAN %d", ESRAPI_SOC, long_press);
+  appendChk(g_sTmp);
+  writeStart();
+  write(g_sTmp);
+  writeEnd();
+}
+#endif // RAPI_BTN
+
 int EvseRapiProcessor::tokenize(char *buf)
 {
   tokens[0] = &buf[1];
@@ -1038,6 +1049,18 @@ void RapiSetWifiMode(uint8_t mode)
 #endif
 #ifdef RAPI_I2C
   g_EIRP.setWifiMode(mode);
+#endif
+}
+#endif // RAPI_WF
+
+#ifdef RAPI_BTN
+void RapiSendButtonPress(uint8_t long_press)
+{
+#ifdef RAPI_SERIAL
+  g_ESRP.sendButtonPress(long_press);
+#endif
+#ifdef RAPI_I2C
+  g_EIRP.sendButtonPress(long_press);
 #endif
 }
 #endif // RAPI_WF

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -83,6 +83,10 @@ $AT evsestate pilotstate currentcapacity vflags
  currentcapacity(decimal): amps
  vflags(hex): m_wVFlags bits
 
+External button press notification - only if RAPI_BTN defined
+When the button is disabled ($FF B 0) send the event via RAPI
+$AN type
+ type: 0 - short press, 1 - long press
 
 Request client WiFi mode - only if RAPI_WF defined
 $WF mode\r
@@ -394,6 +398,7 @@ public:
   void sendEvseState();
   void sendBootNotification();
   void setWifiMode(uint8_t mode); // WIFI_MODE_xxx
+  void sendButtonPress(uint8_t long_press);
   void writeStr(const char *msg) { writeStart();write(msg);writeEnd(); }
 
   virtual void init();
@@ -441,6 +446,7 @@ void RapiInit();
 void RapiDoCmd();
 void RapiSendEvseState(uint8_t nodupe=1);
 void RapiSetWifiMode(uint8_t mode);
+void RapiSendButtonPress(uint8_t long_press);
 void RapiSendBootNotification();
 
 #endif // RAPI

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ src_dir = firmware/open_evse
 [common]
 lib_deps =
 upload_protocol = usbasp
-upload_flags = -p m328p -B0.5 -Pusb
+upload_flags = -e
 
 [env:openevse]
 


### PR DESCRIPTION
When the front panel button is disabled via `$FF B 0` the button state is evented using `$AN` for processing on the external controller.

Also re-enabled eventing of the 10s WiFi mode press.

Missing part of #111 and needed for OpenEVSE/ESP32_WiFi_V3.x#68 and OpenEVSE/ESP32_WiFi_V3.x#5