### PR TITLE
RTC setting improvement via push button menu

### DIFF
--- a/firmware/open_evse/main.cpp
+++ b/firmware/open_evse/main.cpp
@@ -1783,8 +1783,8 @@ Menu *RTCMenuDay::Select()
 RTCMenuYear::RTCMenuYear()
 {
 }
-#define YEAR_MIN 18
-#define YEAR_MAX 28
+#define YEAR_MIN 23
+#define YEAR_MAX 33
 void RTCMenuYear::Init()
 {
   g_OBD.LcdPrint_P(0,g_psRTC_Year);


### PR DESCRIPTION
If Real-Time Clock isn't set, and if we're not setting via the wifi module then the YEAR_MIN should now be a bit more recent to save button pushes. Perhaps YEAR_MAX for the pushbutton menu interface should be more than 10 years later? What's the expected lifespan of this system before we'd expect firmware updates to be applied?