### PR TITLE
pio.ini: bump atmelavr to 3.4.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ upload_flags = -F -e
 [env:openevse]
 
 #platform = atmelavr@1.15.0
-platform = atmelavr@3.0.0
+platform = atmelavr@3.4.0
 build_src_flags = 
  -DOEV6
  -DRELAY_PWM


### PR DESCRIPTION
Unfortunately, since commit 3ad2310 it is not possible to use platformio
on Linux:

	$ pio run
	Processing openevse (platform: atmelavr@3.0.0; board: openevse; framework: arduino)
	-------------------------------------------------------------------------------------------------------------------
	Platform Manager: Installing atmelavr @ 3.0.0
	UnknownPackageError: Could not find the package with 'atmelavr @ 3.0.0' requirements for your system 'linux_x86_64'

I think that it will also make it impossible to build via using Github
Actions.

Looking into https://github.com/platformio/platform-atmelavr/releases,
I've tried using 3.1.0 and 3.2.0 -- with errors similar as the one above.

Updated to 3.4.0 (which appears to be the latest 3.x version) fixes the
issue.

Note I've also tried building with different versions of atmelavr (with
"pio run -t clean" in between to ensure everything is being rebuilt) and
the resulting firmware.hex is the same for all versions (from 3.3.0 to
5.0.0, except

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
